### PR TITLE
Use Obsidian's current frontmatter name for tags

### DIFF
--- a/standard-notes-to-markdown.php
+++ b/standard-notes-to-markdown.php
@@ -207,7 +207,7 @@ foreach ($notes as $note_uuid => $note_data) {
 
 		// manual tag YAML
 		if(!empty($note_data['tags'])) {
-			$note_tags_yaml = "keywords:\n";
+			$note_tags_yaml = "tags:\n";
 			foreach ($note_data['tags'] as $note_tag_title => $value) {
 				$note_tags_yaml .= "  - $note_tag_title\n";
 			}


### PR DESCRIPTION
Hey, thanks for this script, it was very useful to me. Obsidian now uses the 'tags' name for tags, so I changed that to make it work properly.