### PR TITLE
Add support for super noteType

### DIFF
--- a/standard-notes-to-markdown.php
+++ b/standard-notes-to-markdown.php
@@ -330,8 +330,17 @@ function parseChild($child)
 				case "h3":
 					$prefix = "### ";
 					break;
+				case "h4":
+					$prefix = "#### ";
+					break;
+				case "h5":
+					$prefix = "##### ";
+					break;
+				case "h6":
+					$prefix = "###### ";
+					break;
 				default:
-					$prefix = "todo: header-tag=$tag";
+					$prefix = "todo: header-tag=$tag ";
 			}
 			return $prefix.join("",
 					array_map(function ($c) {

--- a/standard-notes-to-markdown.php
+++ b/standard-notes-to-markdown.php
@@ -318,8 +318,8 @@ function parseChild($child, $note_filename)
 			if(!$child['children']) {
 				return "\n#error: code without children\n";
 			}
-			if(firstChildIsType($child['children'], "code")) {
-				if (!hasSingleChild($child['children'])) {
+			if(firstChildIsType($child, "code")) {
+				if (!hasSingleChild($child)) {
 					// confirm only 1 child -> lazyness assuming this case never occurs
 					// if it does occur, you will want to co something more complicated than getting [0]'t child and ignoring the rest
 					return "\n#error: nested code with multiple children\n";
@@ -353,7 +353,7 @@ function parseChild($child, $note_filename)
 function parseList($list, $note_filename): string
 {
 	// skip weird nesting
-	if (firstOnlyChildHasType($list['children'], "listitem") && firstOnlyChildHasType($list['children'][0]['children'], "list")) {
+	if (firstOnlyChildHasType($list, "listitem") && firstOnlyChildHasType($list['children'][0], "list")) {
 		return parseList($list['children'][0]['children'][0], $note_filename);
 	}
 
@@ -414,18 +414,16 @@ function firstOnlyChildHasType($parent, $type): bool
  */
 function firstChildIsType($parent, $type): bool
 {
-	// todo: fix: should be parent['children']
-	return $parent[0]['type'] == $type;
+	return $parent['children'][0]['type'] == $type;
 }
 
 /**
- * @param $children
+ * @param $parent
  * @return bool
  */
-function hasSingleChild($children): bool
+function hasSingleChild($parent): bool
 {
-	// todo: should get $parent instead of $children
-	return count($children) == 1;
+	return count($parent['children']) == 1;
 }
 
 /**

--- a/standard-notes-to-markdown.php
+++ b/standard-notes-to-markdown.php
@@ -89,10 +89,14 @@ Standard Note Tag titles contain a dot `.` if a paid account (called "Extended")
 
 */
 
+$EXPECTED_CALL_SYNTAX = 'expected format: php standard-notes-to-markdown.php <path-to-backup.txt> [<foldername-tooutput-notes>] [<path-to-folder-you-created-with-attachments>]
+example: php standard-notes-to-markdown.php "/Users/foo/Downloads/Standard Notes Backup - Tue Jul 09 2024 11_28_53 GMT+0100/Standard Notes Backup and Import File.txt" /notes/ "/Users/foo/Downloads/standard-notes-attachments/"
+';
 
 // Require Args
 if(!isset($argv[1])) {
-	echo 'Error: Need to pass the Standard Notes file path as argument/parameter 1';
+	echo 'Error: Need to pass the Standard Notes file path as argument/parameter 1\n';
+	echo $EXPECTED_CALL_SYNTAX;
 	exit;
 }
 else $sn_file = file_get_contents($argv[1]);
@@ -103,7 +107,7 @@ else $export_path = __DIR__.trim($argv[2]);
 /**
  * (optional) third argument to be a folder containing standard notes files in the format of <uuid>.<ext>
  * <br/>
- * examples: 5e97c50b-ea24-4b52-bd05-b902594b367a.png, 9a09b759-6ab7-4431-b7b3-6096c4635fb8.df
+ * examples: 5e97c50b-ea24-4b52-bd05-b902594b367a.png, 9a09b759-6ab7-4431-b7b3-6096c4635fb8.pdf
  */
 if(!isset($argv[3])) $resourceFilesDir = false;
 else $resourceFilesDir = $argv[3];
@@ -118,7 +122,8 @@ if(file_exists($export_path)) {
 }
 // sanity
 if($resourceFilesDir && !file_exists($resourceFilesDir)) {
-	echo 'Error: ResourceFileDir is set, but folder does not exist.';
+	echo 'Error: ResourceFileDir is set, but folder does not exist.\n';
+	echo $EXPECTED_CALL_SYNTAX;
 	exit;
 }
 else {

--- a/standard-notes-to-markdown.php
+++ b/standard-notes-to-markdown.php
@@ -282,7 +282,7 @@ function parseChild($child, $note_filename)
 					$prefix = "###### ";
 					break;
 				default:
-					$prefix = "todo: header-tag=$tag ";
+					$prefix = "#error: header-tag=$tag ";
 			}
 			return $prefix.joinChildren("", $child['children'], $note_filename);
 		case "horizontalrule":
@@ -305,7 +305,7 @@ function parseChild($child, $note_filename)
 			return "\n".joinChildren("\n", $child['children'], $note_filename)."\n";
 		case "code":
 			if(!$child['children']) {
-				return "\ntodo: code without children\n";
+				return "\n#error: code without children\n";
 			}
 			if($child['children'][0]['type'] == "code") {
 				// todo: confirm only 1 child
@@ -325,7 +325,7 @@ function parseChild($child, $note_filename)
 		case "tab":
 			return "\t";
 		default:
-			return "todo: $type";
+			return "#error: $type";
 	}
 }
 
@@ -438,7 +438,7 @@ function findFormatWrappers($format)
 			$format_suffix = "`</u>~~**";
 			break;
 		default:
-			$format_prefix = "todo: text-format-unknown_format='$format'";
+			$format_prefix = "#error: text-format-unknown_format='$format'";
 	}
 	return array($format_prefix, $format_suffix);
 }
@@ -511,5 +511,6 @@ foreach($notes as $note_uuid => $note_data) {
 }
 
 echo "Exported $exported_count Notes to: $export_path\n";
+echo "Please also check the .md files for '#error:' to check if things failed";
 
 ?>

--- a/standard-notes-to-markdown.php
+++ b/standard-notes-to-markdown.php
@@ -319,7 +319,11 @@ function parseChild($child, $note_filename)
 				return "\n#error: code without children\n";
 			}
 			if(firstChildIsType($child['children'], "code")) {
-				// todo: confirm only 1 child
+				if (!hasSingleChild($child['children'])) {
+					// confirm only 1 child -> lazyness assuming this case never occurs
+					// if it does occur, you will want to co something more complicated than getting [0]'t child and ignoring the rest
+					return "\n#error: nested code with multiple children\n";
+				}
 				// don't do anything the nested code will do all that needs to happen
 				return parseChild($child['children'][0], $note_filename);
 			}
@@ -410,6 +414,7 @@ function firstOnlyChildHasType($parent, $type): bool
  */
 function firstChildIsType($parent, $type): bool
 {
+	// todo: fix: should be parent['children']
 	return $parent[0]['type'] == $type;
 }
 
@@ -419,6 +424,7 @@ function firstChildIsType($parent, $type): bool
  */
 function hasSingleChild($children): bool
 {
+	// todo: should get $parent instead of $children
 	return count($children) == 1;
 }
 

--- a/standard-notes-to-markdown.php
+++ b/standard-notes-to-markdown.php
@@ -255,7 +255,8 @@ function parseChild($child, $note_filename)
 			$indent = $child['indent'];
 			$paragraphSeparator = "";
 			if ($indent && $indent > 0) {
-				$paragraphSeparator .= str_repeat("$\quad$", $indent);
+//				$paragraphSeparator .= str_repeat("$\quad$", $indent); // hack to make it look tab-like
+				$paragraphSeparator .= str_repeat("    ", $indent); // convert into quote
 			}
 			// todo: should I replace every newline with `$indent * \t + \n`
 			return $paragraphSeparator . joinChildren($paragraphSeparator, $child['children'], $note_filename);

--- a/standard-notes-to-markdown.php
+++ b/standard-notes-to-markdown.php
@@ -219,7 +219,7 @@ foreach ($notes as $note_uuid => $note_data) {
 		else $note_status_yaml = '';
 
 		// manual note YAML
-		$note_yaml = "---\ntitle: $note_data[title]\ncreated: $note_data[created_at]\nuuid: $note_uuid\nid: $note_id\n$note_tags_yaml$note_status_yaml---\n\n";
+		$note_yaml = "---\ntitle: $note_data[title]\ncreated: $note_data[created_at]\nupdated: $note_data[updated_at]\nuuid: $note_uuid\nid: $note_id\n$note_tags_yaml$note_status_yaml---\n\n";
 
 		$filename = preg_replace("([^\w\s\d\-_~,;\[\]\(\).])", '-', $note_data['title'])." $note_id.md";
 		$note_content = $note_yaml.$note_data['sn_content'];


### PR DESCRIPTION
summary:
1) added 'updated' to frontmatter yaml

2) handle noteType super 
otherwise the note content just becomes a single-line json mess (which is standard-note's internal representation for 'super' notes)
```json
{"root":{"children":[{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"Clip source: ","type":"text","version":1},...
```
should not change anything unless the note-type is 'super'

This probably does not parse everything possible in a 'super' node, but it parses all of my cases.
Cases I didn't handle, show up as  text in the <note>.md files `#error: ...`. 
(adding those error as a tag seemed like a nice touch)

Anyway, thank you for the script!